### PR TITLE
Replaces TODO with upgrade-friendly migration for adding return_label_im...

### DIFF
--- a/app/code/community/IllApps/Shipsync/sql/shipsync_setup/mysql4-upgrade-0.5.0.0-0.5.1.php
+++ b/app/code/community/IllApps/Shipsync/sql/shipsync_setup/mysql4-upgrade-0.5.0.0-0.5.1.php
@@ -14,7 +14,7 @@ $installer = $this;
 
 $installer->startSetup();
 
-/** TODO: add a check to make sure these columns don't exist */
-$installer->run("ALTER TABLE `{$this->getTable('shipping_shipment_package')}` ADD `return_label_image` MEDIUMBLOB NOT NULL AFTER cod_label_image;");
+$connection = $this->getConnection();
+$connection->addColumn($this->getTable('shipping_shipment_package'), 'return_label_image', 'MEDIUMBLOB NOT NULL AFTER cod_label_image');
 
 $installer->endSetup();

--- a/app/code/community/IllApps/Shipsync/sql/shipsync_setup/mysql4-upgrade-0.5.0.1-0.5.1.php
+++ b/app/code/community/IllApps/Shipsync/sql/shipsync_setup/mysql4-upgrade-0.5.0.1-0.5.1.php
@@ -14,7 +14,7 @@ $installer = $this;
 
 $installer->startSetup();
 
-/** TODO: add a check to make sure these columns don't exist */
-$installer->run("ALTER TABLE `{$this->getTable('shipping_shipment_package')}` ADD `return_label_image` MEDIUMBLOB NOT NULL AFTER cod_label_image;");
+$connection = $this->getConnection();
+$connection->addColumn($this->getTable('shipping_shipment_package'), 'return_label_image', 'MEDIUMBLOB NOT NULL AFTER cod_label_image');
 
 $installer->endSetup();


### PR DESCRIPTION
...age to shipping_shipment_package table.

Made possible by Varien_Db_Adapter_Mysqli's `addColumn`, which checks for an existing column of the same name before actually adding it.

https://github.com/LokeyCoding/magento-mirror/blob/magento-1.7/lib/Varien/Db/Adapter/Mysqli.php#L240

Tested against 1.7.0.2 with no problems. `addColumn` hasn't changed since 1.1.1 (circa 2009) so this change should be safe for most any Magento installation.
