### PR TITLE
Shipsync support for Magento compilation

### DIFF
--- a/app/code/community/IllApps/Shipsync/Model/Shipping/Carrier/Fedex.php
+++ b/app/code/community/IllApps/Shipsync/Model/Shipping/Carrier/Fedex.php
@@ -112,13 +112,13 @@ class IllApps_Shipsync_Model_Shipping_Carrier_Fedex extends Mage_Usa_Model_Shipp
             $this->setFedexPassword(Mage::getStoreConfig('carriers/fedex/test_password'));
             $this->setFedexAccount(Mage::getStoreConfig('carriers/fedex/test_account'));
             $this->setFedexMeter(Mage::getStoreConfig('carriers/fedex/test_meter'));
-            $this->setWsdlPath(dirname(__FILE__) . '/Fedex/wsdl/test/' . $wsdlPath);
+            $this->setWsdlPath(Mage::getModuleDir('', 'IllApps_Shipsync') . '/Model/Shipping/Carrier/Fedex/wsdl/test/' . $wsdlPath);
         } else {
             $this->setFedexKey(Mage::getStoreConfig('carriers/fedex/key'));
             $this->setFedexPassword(Mage::getStoreConfig('carriers/fedex/password'));
             $this->setFedexAccount(Mage::getStoreConfig('carriers/fedex/account'));
             $this->setFedexMeter(Mage::getStoreConfig('carriers/fedex/meter_number'));
-            $this->setWsdlPath(dirname(__FILE__) . '/Fedex/wsdl/' . $wsdlPath);
+            $this->setWsdlPath(Mage::getModuleDir('', 'IllApps_Shipsync') . '/Model/Shipping/Carrier/Fedex/wsdl/' . $wsdlPath);
         }
         
         try {


### PR DESCRIPTION
Add support for Magento compilation.  Previous code would try to load wsdl files from the compiled path (/includes folder in Magento root).  New code goes directly to the module directory where the wsdl files live.
